### PR TITLE
Screenshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 tmp/*
+web/static/images/screenshot.png
 __pycache__/*
 modules/__pycache__/*
 waveshare_lib/build/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.pyc
 tmp/*
-web/static/images/screenshot.png
 __pycache__/*
 modules/__pycache__/*
 waveshare_lib/build/*

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ curl http://localhost:5000/api/status
 }
 ```
 
+## /api/screenshot [GET]
+
+Returns the currently displayed image from the video file. This is a binary PNG file. Can be saved directly via something like `curl` or embedded in another web application.
+
 ### /api/analyze [POST]
 
 Takes the same parameters as the ```/api/configuration``` POST method, however this will run the analyzer on the proposed configuration. The response includes a break down of each video analyzed.

--- a/modules/twinepd.py
+++ b/modules/twinepd.py
@@ -1,5 +1,7 @@
 from omni_epd import displayfactory
 
+# twins a real EPD so output can be drawn to it and a mock (file) at the same time
+# main omni-epd methods are used so this is a 1:1 replacement in code
 class TwinEpd:
     epd_list = None
     width = 0

--- a/modules/twinepd.py
+++ b/modules/twinepd.py
@@ -1,0 +1,36 @@
+from omni_epd import displayfactory
+
+class TwinEpd:
+    epd_list = None
+    width = 0
+    height = 0
+
+    def __init__(self, epd):
+        # clone the width and height of the main EPD
+        self.width = epd.width
+        self.height = epd.height
+
+        # add to list
+        self.epd_list = [epd]
+
+        # create the mock epd and add to the list
+        mock = displayfactory.load_display_driver('omni_epd.mock')
+        mock.width = self.width
+        mock.height = self.height
+        self.epd_list.append(mock)
+
+    def prepare(self):
+        for e in self.epd_list:
+            e.prepare()
+
+    def display(self, image):
+        for e in self.epd_list:
+            e.display(image)
+
+    def sleep(self):
+        for e in self.epd_list:
+            e.sleep()
+
+    def close(self):
+        for e in self.epd_list:
+            e.close()

--- a/modules/twinepd.py
+++ b/modules/twinepd.py
@@ -1,5 +1,6 @@
 from omni_epd import displayfactory
 
+
 # twins a real EPD so output can be drawn to it and a mock (file) at the same time
 # main omni-epd methods are used so this is a 1:1 replacement in code
 class TwinEpd:

--- a/modules/webapp.py
+++ b/modules/webapp.py
@@ -38,7 +38,7 @@ def webapp_thread(port_number, debugMode=False, logHandlers=[]):
 
     @app.route('/screenshot', methods=['GET'])
     def screenshot():
-        return render_template('screenshot.html')
+        return render_template('screenshot.html', file_info=utils.read_db(db, utils.DB_LAST_PLAYED_FILE))
 
     @app.route('/analyze', methods=['GET'])
     def setup_analyze():

--- a/modules/webapp.py
+++ b/modules/webapp.py
@@ -3,7 +3,7 @@ import os
 import redis
 import logging
 from modules.videoinfo import VideoInfo
-from flask import Flask, render_template, jsonify, request
+from flask import Flask, render_template, jsonify, request, send_file
 from modules.analyze import Analyzer
 
 
@@ -37,7 +37,7 @@ def webapp_thread(port_number, debugMode=False, logHandlers=[]):
         return render_template('setup.html', config=utils.get_configuration(db))
 
     @app.route('/screenshot', methods=['GET'])
-    def screenshot():
+    def screenshot_view():
         return render_template('screenshot.html', file_info=utils.read_db(db, utils.DB_LAST_PLAYED_FILE))
 
     @app.route('/analyze', methods=['GET'])
@@ -127,6 +127,11 @@ def webapp_thread(port_number, debugMode=False, logHandlers=[]):
             result['message'] = 'Not a valid control action'
 
         return jsonify(result)
+
+    @app.route('/api/screenshot', methods=['GET'])
+    def screenshot():
+        # load the image from tmp directory and output as response
+        return send_file(os.path.join(utils.TMP_DIR, 'screenshot.png'), mimetype="image/png")
 
     @app.route('/api/status', methods=['GET'])
     def status():

--- a/modules/webapp.py
+++ b/modules/webapp.py
@@ -36,6 +36,10 @@ def webapp_thread(port_number, debugMode=False, logHandlers=[]):
     def setup_view():
         return render_template('setup.html', config=utils.get_configuration(db))
 
+    @app.route('/screenshot', methods=['GET'])
+    def screenshot():
+        return render_template('screenshot.html')
+
     @app.route('/analyze', methods=['GET'])
     def setup_analyze():
         return render_template('analyze.html', config=utils.get_configuration(db))

--- a/omni-epd.ini
+++ b/omni-epd.ini
@@ -1,0 +1,2 @@
+[omni_epd.mock]
+file=tmp/screenshot.png

--- a/omni-epd.ini
+++ b/omni-epd.ini
@@ -1,2 +1,2 @@
 [omni_epd.mock]
-file=tmp/screenshot.png
+file=web/static/images/screenshot.png

--- a/omni-epd.ini
+++ b/omni-epd.ini
@@ -1,3 +1,3 @@
 [omni_epd.mock]
 mode=color
-file=web/static/images/screenshot.png
+file=tmp/screenshot.png

--- a/omni-epd.ini
+++ b/omni-epd.ini
@@ -1,2 +1,3 @@
 [omni_epd.mock]
+mode=color
 file=web/static/images/screenshot.png

--- a/vsmp.py
+++ b/vsmp.py
@@ -4,6 +4,7 @@ import logging
 import os
 import modules.utils as utils
 from modules.videoinfo import VideoInfo
+from modules.twinepd import TwinEpd
 import signal
 import sys
 import time
@@ -271,8 +272,8 @@ if(args.epd not in validEpds):
     # can't get past this
     exit(1)
 
-# setup the screen and database connection
-epd = displayfactory.load_display_driver(args.epd)
+# setup the epds and database connection
+epd = TwinEpd(displayfactory.load_display_driver(args.epd))
 
 # pull width/height from driver
 width = epd.width

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -23,6 +23,7 @@
             </a>
               <div class="dropdown-menu" aria-labelledby="playerMenu">
                 <a class="dropdown-item" href="/">Status</a>
+                <a class="dropdown-item" href="/screenshot">Screenshot</a>
                 <a class="dropdown-item" href="/setup">Setup</a>
               </div>
           </div>

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -22,7 +22,7 @@
               Player
             </a>
               <div class="dropdown-menu" aria-labelledby="playerMenu">
-                <a class="dropdown-item" href="/">Status</a>
+                <a class="dropdown-item" href="/">Controls</a>
                 <a class="dropdown-item" href="/screenshot">Screenshot</a>
                 <a class="dropdown-item" href="/setup">Setup</a>
               </div>

--- a/web/templates/screenshot.html
+++ b/web/templates/screenshot.html
@@ -10,7 +10,7 @@
   </div>
   <div class="row mb-2 mt-2">
     <div class="col-lg text-center">
-      <img src="/static/images/screenshot.png" />
+      <img src="/api/screenshot" />
     </div>
   </div>
   <div class="row">

--- a/web/templates/screenshot.html
+++ b/web/templates/screenshot.html
@@ -5,7 +5,7 @@
 <div class="container">
   <div class="row">
     <div class="col-lg-8">
-      <h2>Screenshot</h2>
+      <h2>{{ file_info['info']['title'] }} - {{ file_info['percent_complete'] | int }}%</h2>
     </div>
   </div>
   <div class="row mb-2 mt-2">
@@ -19,4 +19,12 @@
     </div>
   </div>
 </div>
+<script type="text/javascript">
+  function reload_page(){
+    location.reload();
+  }
+  $(document).ready(function () {
+    setTimeout(reload_page, 30000);
+  });
+</script>
 {% endblock %}

--- a/web/templates/screenshot.html
+++ b/web/templates/screenshot.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block header %}
+{% endblock %}
+{% block content %}
+<div class="container">
+  <div class="row">
+    <div class="col-lg-8">
+      <h2>Screenshot</h2>
+    </div>
+  </div>
+  <div class="row mb-2 mt-2">
+    <div class="col-lg text-center">
+      <img src="/static/images/screenshot.png" />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-lg">
+      <p>This is the image that should currently be displayed on the real EPD. To perform adjustments on this image you must edit the <code>omni-epd.ini</code> file.</p>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This adds support for displaying a screenshot of the current EPD display within the web GUI. This is done by utilizing the `omni-epd.mock` class to export a file of whatever image is written to the main display. 

An additional `omni-epd.ini` file is added to load defaults for the mock display class at startup. By default the mock class is loaded in color mode as opposed to black and white. This can be changed by the user if desired. 